### PR TITLE
Allow symbols for frontmatter options

### DIFF
--- a/lib/sinatra/jekyll.rb
+++ b/lib/sinatra/jekyll.rb
@@ -37,7 +37,9 @@ module Sinatra
 
         process(name)
         self.content = content
-        self.data = { 'layout' => 'default' }.merge(options)
+        self.data = Jekyll::Utils.stringify_hash_keys(
+          { 'layout' => 'default' }.merge(options)
+        )
 
         data.default_proc = proc do |_, key|
           site.frontmatter_defaults.find(File.join(dir, name), type, key)

--- a/test/sinatra/jekyll_test.rb
+++ b/test/sinatra/jekyll_test.rb
@@ -10,7 +10,7 @@ class MockSinatraApp < Sinatra::Base
   end
 
   get '/with_options' do
-    render_into_jekyll_layout 'Test', 'layout' => 'another', 'extra_class' => 'foo'
+    render_into_jekyll_layout 'Test', layout: 'another', extra_class: 'foo'
   end
 end
 


### PR DESCRIPTION
Convert frontmatter keys to strings in the `SinatraPage` class to avoid
the need to specify strings when rendering.

Fixes #1 
